### PR TITLE
Extension Page Icon Added

### DIFF
--- a/code/manifest.json
+++ b/code/manifest.json
@@ -12,6 +12,11 @@
       "default_icon": "icon/icon.png"
     },
   "manifest_version": 2,
+  "icons": { 
+          "16": "icon/icon.png",
+          "48": "icon/icon.png",
+          "128": "icon/icon.png" 
+    },
   "content_security_policy": "script-src 'self' https://ajax.googleapis.com; object-src 'self'",
   "short_name": "World's first offline search engine: Quark"
 }


### PR DESCRIPTION
**Fixes issue:** #8 
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->


**Changes:** Missing Extension Icon added to the Extensions management page (chrome://extensions)
<!-- Add here what changes were made in this awesome pull request. -->

![image](https://user-images.githubusercontent.com/13145896/36061602-44b0acca-0e82-11e8-8357-ecc82140fa1a.png)

<!-- Make sure that you enjoyed being the part of the OpenGenus Community. We would love to hear how can we make your contributing experience better. Thank you. Have a nice day! -->