### PR TITLE
Modified popup.html link in sites.html

### DIFF
--- a/code/sites.html
+++ b/code/sites.html
@@ -15,7 +15,7 @@
 <body class="body">
 
 	<nav class="navbar navbar-light  justify-content-between ">
-		<a class="navbar-brand" href="/popup.html"></a>
+		<a class="navbar-brand" href="popup.html"></a>
 		<span class="navbar-text" style="color: rgb(14, 0, 0);">
 			Time spend on various sites
 		</span>


### PR DESCRIPTION
**Fixes issue:**
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->
The link in line 18 in sites.html refers to "/popup.html" which will redirect to the server root. Changed that to link to "popup.html" as it's in the same directory and for mobility.

**Changes:**
<!-- Add here what changes were made in this awesome pull request. -->
<a class="navbar-brand" href="/popup.html"></a> --> <a class="navbar-brand" href="popup.html"></a>
<!-- Make sure that you enjoyed being the part of the OpenGenus Community. We would love to hear how can we make your contributing experience better. Thank you. Have a nice day! -->