### PR TITLE
changes to comments of quick_sort.c

### DIFF
--- a/code/code/sorting/src/quick_sort/quick_sort.c
+++ b/code/code/sorting/src/quick_sort/quick_sort.c
@@ -9,8 +9,8 @@ void swap(int *p, int *q)
 }
 
 
-//Last element is used a spivot
-//Places elements smaller than pivot to its left side
+//Last element is used as pivot
+//Places elements smaller than or equal to pivot to its left side
 //Places elements larger than pivot to its right side
 int partition(int a[], int low, int high)
 {


### PR DESCRIPTION
**Fixes issue:**
changes in the comments of quick_sort.c algorithm .

**Changes:**
*a spivot* changed to *as pivot*.
*smaller than* changed to *smaller than or equal to*

<!-- Make sure that you enjoyed being the part of the OpenGenus Community. We would love to hear how can we make your contributing experience better. Thank you. Have a nice day! -->