### PR TITLE
Fixed js syntax error in Tower of Hanoi

### DIFF
--- a/code/code/mathematical_algorithms/src/tower_of_hanoi/tower_of_hanoi.js
+++ b/code/code/mathematical_algorithms/src/tower_of_hanoi/tower_of_hanoi.js
@@ -16,4 +16,4 @@ function towerOfHanoi(n, from_rod, to_rod, aux_rod) {
     return;
 }
 
-towerOfHanoi(3, "A", "C", "B"));
+towerOfHanoi(3, "A", "C", "B");


### PR DESCRIPTION
**Fixes issue:**
Fixed a syntax error in javascript code Tower of Hanoi


**Changes:**
Removed a ')'